### PR TITLE
[RFR] Fix get all query

### DIFF
--- a/app/service.js
+++ b/app/service.js
@@ -128,7 +128,7 @@ class Service {
         _assertConnection(this);
         const param = {
             record: {
-                $attributes: { recordType: recordType }
+                $attributes: { recordType }
             }
         };
         const getAll = denodeify(this.config.client.getAll);

--- a/app/service.js
+++ b/app/service.js
@@ -118,17 +118,18 @@ class Service {
         return getList(soapObj);
     }
 
+
     /**
-     * Get a list of records by type
-     * @param {string} recordType
-     * @return {Promise<any>}
-     */
+      * Get a list of records by type
+      * @param {string} recordType
+      * @return {Promise<any>}
+      */
     getAll(recordType) {
         _assertConnection(this);
         const param = {
             record: {
-                recordType,
-            },
+                $attributes: { recordType: recordType }
+            }
         };
         const getAll = denodeify(this.config.client.getAll);
         return getAll(param);


### PR DESCRIPTION
The get all query was creating a bad soap request (putting the recordType as a text value instead of an attribute) this fixes that issue. 